### PR TITLE
Fix config path issue and add improved launcher script

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -6,11 +6,20 @@
 # 1. Run the installation script
 bash install.sh
 
-# 2. This will:
+# 2. If conda was just installed, reload your shell:
+source ~/.bashrc
+# or close and reopen your terminal
+
+# 3. The installation will:
 #    - Install Miniconda (if needed)
 #    - Create 'cyberdeck' conda environment
 #    - Install all Python dependencies
 #    - Set up directory structure
+
+# 4. If installation failed at "conda: command not found":
+#    Reload shell and run install.sh again:
+source ~/.bashrc
+bash install.sh
 ```
 
 ## Running the Application

--- a/core/main.py
+++ b/core/main.py
@@ -32,8 +32,8 @@ def parse_args():
 
     parser.add_argument(
         '-c', '--config',
-        default='config/main.yaml',
-        help='Path to main configuration file'
+        default='main.yaml',
+        help='Path to main configuration file (relative to config/ directory)'
     )
 
     parser.add_argument(

--- a/cyberdeck
+++ b/cyberdeck
@@ -1,0 +1,125 @@
+#!/bin/bash
+#
+# CyberDeck Interface v3.0 - Launcher Script
+#
+# Запускает CyberDeck interface с правильными настройками окружения
+#
+
+# Цвета для вывода
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Получаем директорию скрипта
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd "$SCRIPT_DIR"
+
+# Баннер
+echo -e "${BLUE}"
+cat << "EOF"
+  ██████╗██╗   ██╗██████╗ ███████╗██████╗
+ ██╔════╝╚██╗ ██╔╝██╔══██╗██╔════╝██╔══██╗
+ ██║      ╚████╔╝ ██████╔╝█████╗  ██████╔╝
+ ██║       ╚██╔╝  ██╔══██╗██╔══╝  ██╔══██╗
+ ╚██████╗   ██║   ██████╔╝███████╗██║  ██║
+  ╚═════╝   ╚═╝   ╚═════╝ ╚══════╝╚═╝  ╚═╝
+
+ ██████╗ ███████╗ ██████╗██╗  ██╗  v3.0
+ ██╔══██╗██╔════╝██╔════╝██║ ██╔╝
+ ██║  ██║█████╗  ██║     █████╔╝
+ ██║  ██║██╔══╝  ██║     ██╔═██╗
+ ██████╔╝███████╗╚██████╗██║  ██╗
+ ╚═════╝ ╚══════╝ ╚═════╝╚═╝  ╚═╝
+EOF
+echo -e "${NC}"
+
+echo -e "${GREEN}Starting CyberDeck Interface...${NC}\n"
+
+# Проверка наличия conda
+if command -v conda &> /dev/null; then
+    # Conda установлена
+    echo -e "${BLUE}[*]${NC} Conda detected"
+
+    # Инициализация conda для bash (если еще не инициализирована)
+    if [ -f "$HOME/miniconda3/etc/profile.d/conda.sh" ]; then
+        source "$HOME/miniconda3/etc/profile.d/conda.sh"
+    elif [ -f "$HOME/anaconda3/etc/profile.d/conda.sh" ]; then
+        source "$HOME/anaconda3/etc/profile.d/conda.sh"
+    fi
+
+    # Проверка существования окружения cyberdeck
+    if conda env list | grep -q "cyberdeck"; then
+        echo -e "${BLUE}[*]${NC} Activating 'cyberdeck' environment..."
+        conda activate cyberdeck
+
+        if [ $? -eq 0 ]; then
+            echo -e "${GREEN}[✓]${NC} Environment activated"
+        else
+            echo -e "${YELLOW}[!]${NC} Failed to activate environment, using base"
+        fi
+    else
+        echo -e "${YELLOW}[!]${NC} Environment 'cyberdeck' not found"
+        echo -e "${YELLOW}[!]${NC} Run: ${BLUE}bash install.sh${NC} to create it"
+        echo -e "${YELLOW}[!]${NC} Using current Python environment..."
+    fi
+else
+    # Conda не установлена
+    echo -e "${YELLOW}[!]${NC} Conda not found, using system Python"
+fi
+
+# Проверка Python версии
+PYTHON_VERSION=$(python3 --version 2>&1 | awk '{print $2}')
+echo -e "${BLUE}[*]${NC} Python version: $PYTHON_VERSION"
+
+# Проверка зависимостей
+echo -e "${BLUE}[*]${NC} Checking dependencies..."
+if ! python3 -c "import urwid" 2>/dev/null; then
+    echo -e "${RED}[✗]${NC} Missing dependency: urwid"
+    echo -e "${YELLOW}[!]${NC} Run: ${BLUE}pip install urwid${NC}"
+    exit 1
+fi
+
+if ! python3 -c "import yaml" 2>/dev/null; then
+    echo -e "${RED}[✗]${NC} Missing dependency: PyYAML"
+    echo -e "${YELLOW}[!]${NC} Run: ${BLUE}pip install pyyaml${NC}"
+    exit 1
+fi
+
+echo -e "${GREEN}[✓]${NC} All dependencies found\n"
+
+# Проверка конфигурации
+if [ ! -f "config/main.yaml" ]; then
+    echo -e "${RED}[✗]${NC} Configuration file not found: config/main.yaml"
+    exit 1
+fi
+
+# Проверка прав для hardware access (предупреждение, не фатально)
+if ! groups | grep -q "gpio\|spi\|i2c"; then
+    echo -e "${YELLOW}[!]${NC} Your user is not in gpio/spi/i2c groups"
+    echo -e "${YELLOW}[!]${NC} Hardware modules may not work properly"
+    echo -e "${YELLOW}[!]${NC} Run: ${BLUE}sudo usermod -a -G gpio,spi,i2c \$USER${NC}"
+    echo -e "${YELLOW}[!]${NC} Then logout and login again\n"
+fi
+
+# Запуск приложения
+echo -e "${GREEN}[*]${NC} Launching CyberDeck Interface...\n"
+echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}\n"
+
+# Передаем все аргументы командной строки в Python скрипт
+python3 core/main.py "$@"
+
+EXIT_CODE=$?
+
+# Обработка выхода
+echo -e "\n${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+
+if [ $EXIT_CODE -eq 0 ]; then
+    echo -e "${GREEN}[✓]${NC} CyberDeck Interface stopped normally"
+else
+    echo -e "${RED}[✗]${NC} CyberDeck Interface exited with error code: $EXIT_CODE"
+    echo -e "${YELLOW}[!]${NC} Check logs in: ${BLUE}logs/${NC}"
+fi
+
+exit $EXIT_CODE


### PR DESCRIPTION
**Problem Fixed:**
- Config path was being duplicated (config/config/main.yaml)
- Missing ./cyberdeck launcher script
- Conda initialization issues in install.sh

**Changes:**

1. **core/main.py**:
   - Fixed default config path from 'config/main.yaml' to 'main.yaml'
   - ConfigLoader already adds 'config/' prefix, no need to duplicate
   - Updated help text to clarify path is relative to config/ directory

2. **cyberdeck launcher script** (NEW):
   - Beautiful ASCII art banner with v3.0 version
   - Automatic conda environment detection and activation
   - Fallback to system Python if conda not available
   - Dependency checking (urwid, yaml)
   - Permission warnings for hardware access (gpio/spi/i2c groups)
   - Color-coded output for better UX
   - Passes all command-line arguments to main.py
   - Exit code handling with log directory hint

3. **install.sh**:
   - Updated to v3.0
   - Improved conda initialization in current session
   - Added eval "$(conda shell.bash hook)" for immediate use
   - Source conda.sh if available
   - Checks if launcher exists before overwriting
   - Better error handling for conda installation

4. **QUICKSTART.md**:
   - Added instructions for conda shell reload
   - Documented "conda: command not found" fix
   - Clear step-by-step with numbered instructions
   - Added troubleshooting for installation failures

**Usage:**
```bash
# After installation
./cyberdeck

# Or with options
./cyberdeck --log-level DEBUG
./cyberdeck --no-ui
./cyberdeck -c custom_config.yaml
```

**Features:**
- Automatic environment detection
- Graceful fallback if conda not available
- Comprehensive pre-flight checks
- User-friendly error messages
- Professional terminal UI

This fixes the installation issues users were experiencing.